### PR TITLE
Foloseste `user@linux ~ $` ca un generic prompt

### DIFF
--- a/_posts/tutorial/sisteme-operare/2018-02-26-retea.markdown
+++ b/_posts/tutorial/sisteme-operare/2018-02-26-retea.markdown
@@ -51,26 +51,26 @@ Utilitarele prin care putem interacționa cu acest serviciu sunt :
 
 NetworkManager ar trebui sa vina preinstalat, fiind un serviciu esențial, dar se poate instala cu ajutorul comenzii
 ```bash
-yum install NetworkManager
+user@linux ~ $ yum install NetworkManager
 ```
 
 Pentru a verifica starea serviciului, putem folosi următoarele comenzi în terminal
 ```bash
-systemctl status NetworkManager
+user@linux ~ $ systemctl status NetworkManager
 NetworkManager.service - Network Manager
    Loaded: loaded (/lib/systemd/system/NetworkManager.service; enabled)
    Active: active (running) since Fri, 08 Mar 2013 12:50:04 +0100; 3 days ago
 
 ### Putem porni serviciul
-systemctl start NetworkManager
+user@linux ~ $ systemctl start NetworkManager
 ### Putem opri serviciul
-systemctl stop NetworkManager
+user@linux ~ $ systemctl stop NetworkManager
 ### Putem reporni serviciul
-systemctl restart NetworkManager  
+user@linux ~ $ systemctl restart NetworkManager  
 ### Putem pune serviciul să pornească automat la inițializarea sistemului
-systemctl enable NetworkManager
+user@linux ~ $ systemctl enable NetworkManager
 ### Putem pune serviciul să NU pornească automat la inițializarea sistemului
-systemctl disable NetworkManager 
+user@linux ~ $ systemctl disable NetworkManager 
 ```
 
 Informațiile setate cu ajutorul acestor utilitare se pot găsi in locația */etc/sysconfig/* .
@@ -81,9 +81,9 @@ Dacă aceste fișiere sunt editate, pentru a se aplica schimbările specificate 
 
 ```bash
 ### Pentru a reciti toate fișierele 
-nmcli connection reload
+user@linux ~ $ nmcli connection reload
 ### Pentru a reciti un fișier specific
-nmcli con load /etc/sysconfig/network-scripts/ifcfg-ifname
+user@linux ~ $ nmcli con load /etc/sysconfig/network-scripts/ifcfg-ifname
 ```
 
 ## Firewall
@@ -98,14 +98,14 @@ Serviciul firewalld vine cu anumite zone predefinite de firewall.
 
 Putem asocia zonele cu intervale de IP-uri (subreţele) pe care putem aplica anumite filtre/reguli
 ```bash
-root@linux ~ # firewall-cmd --get-zones
+root@linux ~ $ firewall-cmd --get-zones
 block dmz drop external home internal public trusted work
 ```
 
 Vom vedea care sunt dispozitivele de reţea (interfeţele) disponibile - enp3s0 (cablu) şi wlp2s0 (wireless) - şi în care zona sunt asociate intervalele de IP.
 ```bash
 ### Vom lista interfetele şi reţelele asociate
-root@linux ~ # firewall-cmd --get-active-zone
+root@linux ~ $ firewall-cmd --get-active-zone
 public
   interfaces: enp3s0 wlp2s0
 trusted
@@ -115,7 +115,7 @@ trusted
 Pe o anumită zonă, putem vedea care sunt serviciile (porturile şi protocoalele predefinite) accesibile din acea reţea (zona home)
 ```bash
 ### Vom afişa serviciile accesibile asociate cu zona home
-root@linux ~ # firewall-cmd --zone=home --list-services
+root@linux ~ $ firewall-cmd --zone=home --list-services
 ssh mdns samba-client dhcpv6-client
 ```
 Pentru mai multe detalii referitoare la serviciile predefinite, puteţi verifica locaţia */usr/lib/firewalld/services* unde puteţi găsi un XML de configurare pentru fiecare serviciu predefinit şi disponibil in firewalld.
@@ -124,13 +124,13 @@ Pentru mai multe detalii referitoare la serviciile predefinite, puteţi verifica
 Pe o anumită zonă, putem vedea care sunt serviciile (porturile predefinite) accesibile din acea reţea (zona home).
 În exemplul de mai jos putem observa că HTTP şi HTTPS vor fi accesibile atunci când o cerere către aceste servicii va veni din zona publică. 
 ```bash
-root@linux ~ # firewall-cmd --zone=public --list-services
+root@linux ~ $ firewall-cmd --zone=public --list-services
 dhcpv6-client http https
 ```
 
 Vom afişa serviciile accesibile asociate cu zona external - vedem doar SSH ca şi serviciu disponibil.
 ```bash
-root@linux ~ # firewall-cmd --zone=external --list-all
+root@linux ~ $ firewall-cmd --zone=external --list-all
 external
   target: default
   icmp-block-inversion: no
@@ -151,16 +151,16 @@ Pentru a adăuga definiţii noi de servicii - de exemplu myapp - o aplicaţie pe
 
 ```bash
 ### Vom defini un nou serviciu 
-root@brix ~ # firewall-cmd --permanent --new-service=myapp
+root@linux ~ $ firewall-cmd --permanent --new-service=myapp
 success
 ### In acest serviciu vom defini portul 1234 TCP si 1245 UDP
-root@brix ~ # firewall-cmd --permanent --service=myapp --add-port=1234/tcp
+root@linux ~ $ firewall-cmd --permanent --service=myapp --add-port=1234/tcp
 success
-root@brix ~ # firewall-cmd --permanent --service=myapp --add-port=1245/udp
+root@linux ~ $ firewall-cmd --permanent --service=myapp --add-port=1245/udp
 success
 
 ### Putem valida ca un nou fişier XML a fost creat, unde vom găsi configurările făcute mai sus
-root@brix ~ # cat /etc/firewalld/services/myapp.xml
+root@linux ~ $ cat /etc/firewalld/services/myapp.xml
 <?xml version="1.0" encoding="utf-8"?>
 <service>
   <port protocol="tcp" port="1234"/>
@@ -169,15 +169,15 @@ root@brix ~ # cat /etc/firewalld/services/myapp.xml
 
 ### Vom adăuga nou serviciu myapp în zona publică
 ### Atenţie! Fără parametrul --permanent această schimbare nu va persista după repornirea sistemului de operare
-root@brix ~ # firewall-cmd --zone=public --permanent --add-service=myapp
+root@linux ~ $ firewall-cmd --zone=public --permanent --add-service=myapp
 success
 
 ### Este nevoie de un reload pentru ca schimbările noastre să fie aplicate
-root@brix ~ # firewall-cmd --reload
+root@linux ~ $ firewall-cmd --reload
 success
 
 ### Putem valida ca avem un nou serviciu acesibil în zona publică
-root@brix ~ # firewall-cmd --zone=public --list-all
+root@linux ~ $ firewall-cmd --zone=public --list-all
 public (active)
   target: default
   icmp-block-inversion: no


### PR DESCRIPTION
Tutorialul `sisteme-operare/retea/` folosea diferite notatii pentru
prompt. Cea mai problematica este `root@brix ~ #` care e interpretata
drept un comentariu